### PR TITLE
fixed `Directory` cells sometimes not existing

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -444,6 +444,7 @@ function build(c::Connection, dir::Directory{<:Any}, m::Module)
                 olive_notify!(cm,
                 "failed to source olive module",
                 color = "red")
+                print(e)
             end
         end
         style!(srcbutton,"font-size" => 20pt, "color" => "red",

--- a/src/Olive.jl
+++ b/src/Olive.jl
@@ -148,7 +148,7 @@ function session(c::Connection; key::Bool = false)
             if y == "y"
                 c[:Logger].log(" okay, logging in as root.")
                 key = ToolipsSession.gen_ref(16)
-                push!(c[:OliveCore].client_keys[key] => c[:OliveCore].data["root"])
+                push!(c[:OliveCore].client_keys, [key] => c[:OliveCore].data["root"])
                 redirect!(cm, "/?key=$(key)")
             end
         end
@@ -249,7 +249,7 @@ function session(c::Connection; key::Bool = false)
     bod = body("mainbody")
     style!(bod, "overflow" => "hidden")
     push!(bod, notifier,  ui_explorer, ui_topbar, ui_settings, olivemain)
-    script!(c, "load", ["olivemain"], type = "Timeout") do cm::ComponentModifier
+    script!(c, "load", ["olivemain"], type = "Timeout", time = 500) do cm::ComponentModifier
         load_extensions!(c, cm, olmod)
         style!(cm, "loaddiv", "opacity" => 0percent)
         ToolipsSession.insert!(cm, "projectexplorer", 1, work_menu(c))


### PR DESCRIPTION
Prior, directory functions would assume that a path is a file if it is not a directory. The problem is when we have a path which is not a file or a directory. For this case, I will give up on providing that file or directory and move onto the rest of the files or directories.